### PR TITLE
Separate encrypter and decrypter

### DIFF
--- a/exp/services/recoverysigner/internal/crypto/crypto.go
+++ b/exp/services/recoverysigner/internal/crypto/crypto.go
@@ -15,13 +15,13 @@ type Decrypter interface {
 	Decrypt(ciphertext, contextInfo []byte) (plaintext []byte, err error)
 }
 
-func NewEncrypterDecrypter(kmsKeyURI, tinkKeysetJSON string) (interface{}, error) {
+func NewEncrypterDecrypter(kmsKeyURI, tinkKeysetJSON string) (Encrypter, Decrypter, error) {
 	if len(kmsKeyURI) == 0 {
 		return newInsecureEncrypterDecrypter(tinkKeysetJSON)
 	}
 
 	if len(kmsKeyURI) <= 7 {
-		return nil, errors.New("invalid KMS key URI format")
+		return nil, nil, errors.New("invalid KMS key URI format")
 	}
 
 	prefix := kmsKeyURI[0:7]
@@ -29,12 +29,12 @@ func NewEncrypterDecrypter(kmsKeyURI, tinkKeysetJSON string) (interface{}, error
 	case awsPrefix:
 		kmsClient, err := awskms.NewClient(kmsKeyURI)
 		if err != nil {
-			return nil, errors.Wrap(err, "initializing AWS KMS client")
+			return nil, nil, errors.Wrap(err, "initializing AWS KMS client")
 		}
 
 		return newSecureEncrypterDecrypter(kmsClient, kmsKeyURI, tinkKeysetJSON)
 
 	default:
-		return nil, errors.New("unrecognized prefix in KMS Key URI")
+		return nil, nil, errors.New("unrecognized prefix in KMS Key URI")
 	}
 }

--- a/exp/services/recoverysigner/internal/crypto/crypto_test.go
+++ b/exp/services/recoverysigner/internal/crypto/crypto_test.go
@@ -9,7 +9,8 @@ import (
 
 func TestNewEncrypterDecrypter(t *testing.T) {
 	ksPriv := generateHybridKeysetCleartext(t)
-	srvKey, err := NewEncrypterDecrypter("", ksPriv)
+	enc, dec, err := NewEncrypterDecrypter("", ksPriv)
 	require.NoError(t, err)
-	assert.IsType(t, (*InsecureEncrypterDecrypter)(nil), srvKey)
+	assert.NotNil(t, enc)
+	assert.NotNil(t, dec)
 }

--- a/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_insecure.go
+++ b/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_insecure.go
@@ -6,50 +6,29 @@ import (
 	"github.com/google/tink/go/hybrid"
 	"github.com/google/tink/go/insecurecleartextkeyset"
 	"github.com/google/tink/go/keyset"
-	"github.com/google/tink/go/tink"
 	"github.com/stellar/go/support/errors"
 )
 
-var _ tink.AEAD = (*InsecureEncrypterDecrypter)(nil)
-var _ tink.HybridEncrypt = (*InsecureEncrypterDecrypter)(nil)
-var _ tink.HybridDecrypt = (*InsecureEncrypterDecrypter)(nil)
-
-type InsecureEncrypterDecrypter struct {
-	hybridEncrypt tink.HybridEncrypt
-	hybridDecrypt tink.HybridDecrypt
-}
-
-func newInsecureEncrypterDecrypter(tinkKeysetJSON string) (*InsecureEncrypterDecrypter, error) {
+func newInsecureEncrypterDecrypter(tinkKeysetJSON string) (Encrypter, Decrypter, error) {
 	khPriv, err := insecurecleartextkeyset.Read(keyset.NewJSONReader(strings.NewReader(tinkKeysetJSON)))
 	if err != nil {
-		return nil, errors.Wrap(err, "getting key handle for private key")
+		return nil, nil, errors.Wrap(err, "getting key handle for private key")
 	}
 
 	hd, err := hybrid.NewHybridDecrypt(khPriv)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting hybrid decryption primitive")
+		return nil, nil, errors.Wrap(err, "getting hybrid decryption primitive")
 	}
 
 	khPub, err := khPriv.Public()
 	if err != nil {
-		return nil, errors.Wrap(err, "getting key handle for public key")
+		return nil, nil, errors.Wrap(err, "getting key handle for public key")
 	}
 
 	he, err := hybrid.NewHybridEncrypt(khPub)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting hybrid encryption primitive")
+		return nil, nil, errors.Wrap(err, "getting hybrid encryption primitive")
 	}
 
-	return &InsecureEncrypterDecrypter{
-		hybridEncrypt: he,
-		hybridDecrypt: hd,
-	}, nil
-}
-
-func (ks *InsecureEncrypterDecrypter) Encrypt(plaintext, contextInfo []byte) ([]byte, error) {
-	return ks.hybridEncrypt.Encrypt(plaintext, contextInfo)
-}
-
-func (ks *InsecureEncrypterDecrypter) Decrypt(ciphertext, contextInfo []byte) ([]byte, error) {
-	return ks.hybridDecrypt.Decrypt(ciphertext, contextInfo)
+	return he, hd, nil
 }

--- a/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_insecure_test.go
+++ b/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_insecure_test.go
@@ -9,32 +9,32 @@ import (
 
 func TestNewInsecureEncrypterDecrypter(t *testing.T) {
 	ksPriv := generateHybridKeysetCleartext(t)
-	ied, err := newInsecureEncrypterDecrypter(ksPriv)
+	enc, dec, err := newInsecureEncrypterDecrypter(ksPriv)
 	require.NoError(t, err)
-	assert.NotNil(t, ied)
-	assert.NotNil(t, ied.hybridEncrypt)
-	assert.NotNil(t, ied.hybridDecrypt)
+	assert.NotNil(t, enc)
+	assert.NotNil(t, dec)
 
-	ied, err = newInsecureEncrypterDecrypter("")
+	enc, dec, err = newInsecureEncrypterDecrypter("")
 	assert.Error(t, err)
-	assert.Nil(t, ied)
+	assert.Nil(t, enc)
+	assert.Nil(t, dec)
 }
 
 func TestInsecureEncrypterDecrypter_encryptDecrypt(t *testing.T) {
 	ksPriv := generateHybridKeysetCleartext(t)
-	ied, err := newInsecureEncrypterDecrypter(ksPriv)
+	enc, dec, err := newInsecureEncrypterDecrypter(ksPriv)
 	require.NoError(t, err)
 
 	plaintext := []byte("secure message")
 	contextInfo := []byte("context info")
-	ciphertext, err := ied.Encrypt(plaintext, contextInfo)
+	ciphertext, err := enc.Encrypt(plaintext, contextInfo)
 	require.NoError(t, err)
 
-	plaintext2, err := ied.Decrypt(ciphertext, contextInfo)
+	plaintext2, err := dec.Decrypt(ciphertext, contextInfo)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, plaintext2)
 
 	// context info not matching will result in a failed decryption
-	_, err = ied.Decrypt(ciphertext, []byte("wrong info"))
+	_, err = dec.Decrypt(ciphertext, []byte("wrong info"))
 	assert.Error(t, err)
 }

--- a/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_secure_test.go
+++ b/exp/services/recoverysigner/internal/crypto/encrypterdecrypter_secure_test.go
@@ -9,33 +9,32 @@ import (
 
 func TestNewSecureEncrypterDecrypter(t *testing.T) {
 	ksPriv := generateHybridKeysetEncrypted(t)
-	sed, err := newSecureEncrypterDecrypter(mockKMSClient{}, "aws-kms://key-uri", ksPriv)
+	enc, dec, err := newSecureEncrypterDecrypter(mockKMSClient{}, "aws-kms://key-uri", ksPriv)
 	require.NoError(t, err)
-	assert.NotNil(t, sed)
-	assert.NotNil(t, sed.remote)
-	assert.NotNil(t, sed.keyset)
-	assert.NotNil(t, sed.hybridEncrypt)
+	assert.NotNil(t, enc)
+	assert.NotNil(t, dec)
 
-	sed, err = newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", "")
+	enc, dec, err = newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", "")
 	assert.Error(t, err)
-	assert.Nil(t, sed)
+	assert.Nil(t, enc)
+	assert.Nil(t, dec)
 }
 
 func TestSecureEncrypterDecrypter_encryptDecrypt(t *testing.T) {
 	ksPriv := generateHybridKeysetEncrypted(t)
-	sed, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv)
+	enc, dec, err := newSecureEncrypterDecrypter(mockKMSClient{}, "mock-key-uri", ksPriv)
 	require.NoError(t, err)
 
 	plaintext := []byte("secure message")
 	contextInfo := []byte("context info")
-	ciphertext, err := sed.Encrypt(plaintext, contextInfo)
+	ciphertext, err := enc.Encrypt(plaintext, contextInfo)
 	require.NoError(t, err)
 
-	plaintext2, err := sed.Decrypt(ciphertext, contextInfo)
+	plaintext2, err := dec.Decrypt(ciphertext, contextInfo)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, plaintext2)
 
 	// context info not matching will result in a failed decryption
-	_, err = sed.Decrypt(ciphertext, []byte("wrong info"))
+	_, err = dec.Decrypt(ciphertext, []byte("wrong info"))
 	assert.Error(t, err)
 }

--- a/exp/services/recoverysigner/internal/serve/serve.go
+++ b/exp/services/recoverysigner/internal/serve/serve.go
@@ -105,19 +105,9 @@ func getHandlerDeps(opts Options) (handlerDeps, error) {
 	}
 	opts.Logger.Infof("SEP10 JWKS contains %d keys", len(sep10JWKS.Keys))
 
-	ed, err := crypto.NewEncrypterDecrypter(opts.EncryptionKMSKeyURI, opts.EncryptionTinkKeysetJSON)
+	encrypter, decrypter, err := crypto.NewEncrypterDecrypter(opts.EncryptionKMSKeyURI, opts.EncryptionTinkKeysetJSON)
 	if err != nil {
 		return handlerDeps{}, errors.Wrap(err, "error initializing EncrypterDecrypter")
-	}
-
-	encrypter, ok := ed.(crypto.Encrypter)
-	if !ok {
-		return handlerDeps{}, errors.New("EncrypterDecrypter is not an encrypter")
-	}
-
-	decrypter, ok := ed.(crypto.Decrypter)
-	if !ok {
-		return handlerDeps{}, errors.New("EncrypterDecrypter a decrypter")
 	}
 
 	db, err := db.Open(opts.DatabaseURL)


### PR DESCRIPTION
### What
Separate encrypter and decrypter.

### Why
So that we only give the decrypter to code that needs it, reduce risk of exposing keys. This also removes code that isn't needed removing types that were just wrapping other code. This leverages Go's interfaces to focus on us mostly defining interfaces and hooking them up to code in tink in the cases we don't need additional wraps.

### Limitations
I updated the tests but the tests that tested the types and that values are set are not really testing any functionality so removing the types reduces them to just testing that the encrypter/decrypter is not nil.

This is intended for PR stellar/go#2692

cc @howardtw 